### PR TITLE
Add format function to feed

### DIFF
--- a/picot/feed.py
+++ b/picot/feed.py
@@ -1,10 +1,11 @@
 import feedparser
 
 class Feed(object):
-    def __init__(self, url, filter_func=None):
+    def __init__(self, url, filter_func=None, format_func=None):
         if filter_func is None:
             filter_func = lambda x: True
         self.filter_func = filter_func
+        self.format_func = format_func
         self._feed = feedparser.parse(url)
         self._entries = None
 
@@ -21,7 +22,9 @@ class Feed(object):
         return len(self._entries)
 
     def __repr__(self):
-        return "{} ({})".format(
-            self._feed.feed.title,
-            self._feed.feed.link
-        )
+        if self.format_func is None:
+            return "{} ({})".format(
+                self._feed.feed.title,
+                self._feed.feed.link
+            )
+        return '\n'.join([self.format_func(entry) for entry in list(self)])

--- a/test/picot/test_feed.py
+++ b/test/picot/test_feed.py
@@ -102,3 +102,56 @@ def test_feed_filter(original_entries, filter_func, expected_entries, monkeypatc
     feed = picot.feed.Feed('https://some.url', filter_func=filter_func)
     assert(len(feed) == len(expected_entries))
     assert(list(feed) == expected_entries)
+
+@pytest.mark.parametrize(
+    'original_entries,format_func,expected_output',
+    [
+        (
+            single_entry,
+            None,
+            'Feed at https://some.url (https://some.url)',
+        ),
+        (
+            single_entry,
+            lambda x: '',
+            '',
+        ),
+        (
+            single_entry,
+            lambda x: x['title'],
+            'Some entry',
+        ),
+        (
+            multiple_entries,
+            None,
+            'Feed at https://some.url (https://some.url)',
+        ),
+        (
+            multiple_entries,
+            lambda x: '',
+            '''\n''',
+        ),
+        (
+            multiple_entries,
+            lambda x: x['title'],
+            'Some entry\nSome other entry',
+        ),
+    ],
+    ids=[
+        'Single entry - No format',
+        'Single entry - Blank format',
+        'Single entry - Simple format',
+        'Multiple entry - No format',
+        'Multiple entry - Blank format',
+        'Multiple entry - Simple format',
+    ],
+)
+def test_feed_format(original_entries, format_func, expected_output, monkeypatch):
+    def mocked_parse(url):
+        return MockFeed(
+            url,
+            entries=original_entries,
+        )
+    monkeypatch.setattr(feedparser, 'parse', mocked_parse)
+    feed = picot.feed.Feed('https://some.url', format_func=format_func)
+    assert(repr(feed) == expected_output)


### PR DESCRIPTION
With this parameter, a formatting function can be specified to be used on each
entry, when the feed gets asked for `repr`.